### PR TITLE
Editing help command.

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -11,7 +11,7 @@ module.exports = {
             .setAuthor(msg.author.username,msg.author.avatarURL)
             .addField('**__Commands__**','!add-bot {Bots id} {prefix}\n!tag [tag]\n!paste {code}',true)
             .addField('**__Info:__**','Can only be used with the Certified role\nUseful instead of typing tags out\nPlease use if the code is bigger than it should be',true)
-            .addField('**__About__**','Made for the Code::Together server!');
+            .addField('**__About__**','Made for the code::together server!');
         msg.channel.send(embed);
     },
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -11,7 +11,7 @@ module.exports = {
             .setAuthor(msg.author.username,msg.author.avatarURL)
             .addField('**__Commands__**','!add-bot {Bots id} {prefix}\n!tag [tag]\n!paste {code}',true)
             .addField('**__Info:__**','Can only be used with the Certified role\nUseful instead of typing tags out\nPlease use if the code is bigger than it should be',true)
-            .addField('**__About__**','Made for Chip in the Code::Together server!');
+            .addField('**__About__**','Made for the Code::Together server!');
         msg.channel.send(embed);
     },
 };


### PR DESCRIPTION
Original: `Made for Chip in the Code::Together server!`

Now: `Made for the Code::Together server!`

I think the updated version is better and grammatically correct.